### PR TITLE
Feature/explicit entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ result = executor.execute({"texts": ["CRISPR-Cas9 enables precise gene therapy"]
 Install easily using pip:
 
 ```bash
-pip install git+https://github.com/Knowledgator/GLinker.git
+pip install glinker
 ```
 
 Or install from source for development purposes:

--- a/README.md
+++ b/README.md
@@ -237,6 +237,28 @@ executor = ProcessorFactory.create_simple(
 )
 ```
 
+**With external NER entities (skip built-in entity discovery):**
+
+When you already have NER results from an external framework (spaCy, Stanza, a custom model, etc.), pass `external_entities=True` to feed pre-extracted mentions directly into the linking pipeline. Each input text must be accompanied by a list of entity dicts with `text`, `start`, and `end` keys:
+
+```python
+executor = ProcessorFactory.create_simple(
+    model_name="knowledgator/gliner-linker-base-v1.0",
+    entities="data/entities.jsonl",
+    external_entities=True,
+)
+
+result = executor.execute({
+    "texts": ["CRISPR-Cas9 enables precise gene therapy."],
+    "entities": [[
+        {"text": "CRISPR-Cas9", "start": 0, "end": 11},
+        {"text": "gene therapy", "start": 28, "end": 40}
+    ]]
+})
+```
+
+The pipeline uses `strict_matching=True` in this mode since external NER provides precise spans — L0 will only output entities at the positions you provide.
+
 **All `create_simple` parameters:**
 
 | Parameter | Default | Description |
@@ -253,6 +275,7 @@ executor = ProcessorFactory.create_simple(
 | `reranker_model` | `None` | GLiNER model for L4 reranking (adds L4 node when set) |
 | `reranker_max_labels` | `20` | Max candidate labels per L4 inference call |
 | `reranker_threshold` | `None` | Score threshold for L4 (defaults to `threshold`) |
+| `external_entities` | `False` | Read pre-extracted entity mentions from `$input.entities` (list of dicts with `text`, `start`, `end`) |
 
 ### Option 2: From a YAML config file
 
@@ -294,6 +317,26 @@ builder.l2.add("postgres", priority=0)
 builder.l3.configure(model="knowledgator/gliner-linker-large-v1.0", use_precomputed_embeddings=True)
 builder.l0.configure(strict_matching=True, min_confidence=0.3)
 builder.save("config.yaml")
+```
+
+**Linking-only mode (skip L1, use external NER):**
+
+When you omit the L1 configuration, `ConfigBuilder` automatically creates a linking-only pipeline (L2 → L3 → L0) that reads pre-extracted entities from `$input.entities`:
+
+```python
+builder = ConfigBuilder(name="linking_only")
+builder.l3.configure(model="knowledgator/gliner-linker-base-v1.0")
+
+executor = DAGExecutor(builder.get_config())
+executor.load_entities("data/entities.jsonl")
+
+result = executor.execute({
+    "texts": ["CRISPR-Cas9 enables precise gene therapy."],
+    "entities": [[
+        {"text": "CRISPR-Cas9", "start": 0, "end": 11},
+        {"text": "gene therapy", "start": 28, "end": 40}
+    ]]
+})
 ```
 
 **With L4 reranker:**
@@ -409,10 +452,11 @@ GLiNKER uses a **layered pipeline** with an optional reranking stage:
 
 **Supported topologies:**
 ```
-Full pipeline:       L1 → L2 → L3 → L0
-With reranking:      L1 → L2 → L3 → L4 → L0
-Simple (no NER):          L2 → L3 → L0
-Simple + reranker:        L2 → L4 → L0
+Full pipeline:               L1 → L2 → L3 → L0
+With reranking:              L1 → L2 → L3 → L4 → L0
+Simple (no NER):                  L2 → L3 → L0
+Simple + reranker:                L2 → L4 → L0
+External entities (no L1):       L2 → L3 → L0   (mentions from input)
 ```
 
 **Key Concepts:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "glinker"
-version = "0.1.0"
+version = "0.1.1"
 description = "GLiNKER - A modular multi-layer entity linking framework"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -26,7 +26,7 @@ classifiers = [
 
 dependencies = [
     "spacy>=3.7.0",
-    "gliner @ git+https://github.com/urchade/GLiNER.git@503f85b28939a46827b92d9b9f358b9d58e5e510",
+    "gliner>=0.2.5",
     "torch>=2.0.0",
     "redis>=5.0.0",
     "elasticsearch>=8.11.0",

--- a/src/glinker/__init__.py
+++ b/src/glinker/__init__.py
@@ -3,7 +3,7 @@ GLiNKER - Entity Linking Framework
 A modular 4-layer entity linking pipeline using spaCy NER, database search, and GLiNER.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 from glinker.l0 import processor as _l0_processor
 from glinker.l1 import processor as _l1_processor

--- a/src/glinker/l0/component.py
+++ b/src/glinker/l0/component.py
@@ -26,6 +26,22 @@ class L0Component(BaseComponent[L0Config]):
             "calculate_stats"
         ]
 
+    @staticmethod
+    def _normalize_entity(e) -> L1Entity:
+        """Convert a dict entity to L1Entity, passing through L1Entity objects unchanged."""
+        if isinstance(e, L1Entity):
+            return e
+        if isinstance(e, dict):
+            return L1Entity(
+                text=e["text"],
+                start=e["start"],
+                end=e["end"],
+                label=e.get("label"),
+                left_context=e.get("left_context", ""),
+                right_context=e.get("right_context", ""),
+            )
+        return e
+
     def aggregate(
         self,
         l1_entities: List[List[L1Entity]],
@@ -45,6 +61,12 @@ class L0Component(BaseComponent[L0Config]):
         Returns:
             [[L0Entity, ...], ...] - aggregated entities per text
         """
+        # Normalize dict entities to L1Entity objects
+        l1_entities = [
+            [self._normalize_entity(e) for e in text_ents]
+            for text_ents in l1_entities
+        ]
+
         all_results = []
 
         # Process each text separately

--- a/src/glinker/l3/processor.py
+++ b/src/glinker/l3/processor.py
@@ -38,7 +38,11 @@ class L3Processor(BaseProcessor[L3Config, L3Input, L3Output]):
             List of span dicts with 'start' and 'end' keys,
             wrapped in an outer list as expected by GLiNER input_spans.
         """
-        spans = [{"start": e.start, "end": e.end} for e in l1_entities_for_text]
+        spans = [
+            {"start": e["start"] if isinstance(e, dict) else e.start,
+             "end": e["end"] if isinstance(e, dict) else e.end}
+            for e in l1_entities_for_text
+        ]
         return [spans]
 
     def __call__(


### PR DESCRIPTION
# Support external NER entities (skip L1)                  
                                                                                                                                                     
  Add external_entities=True to create_simple() so users can feed pre-extracted entity mentions (with text, start, end) directly into the linking    
  pipeline (L2 → L3 → L0), bypassing built-in entity discovery.

  - create_simple(external_entities=True) wires input mentions into L2/L3/L0, uses strict matching
  - ConfigBuilder.build() without L1 config auto-generates a linking-only topology
  - L3 and L0 now accept both L1Entity objects and plain dicts
  
  
  
  ```python
result = executor.execute({
    "texts": ["CRISPR-Cas9 enables precise gene therapy."],
    "entities": [[
        {"text": "CRISPR-Cas9", "start": 0, "end": 11},
        {"text": "gene therapy", "start": 28, "end": 40},
    ]],
})
```